### PR TITLE
chore: remove vestigial .wfctl-lock.yaml

### DIFF
--- a/.wfctl-lock.yaml
+++ b/.wfctl-lock.yaml
@@ -1,6 +1,0 @@
-version: 1
-generated_at: 2026-05-06T05:38:42Z
-plugins:
-    ratchet:
-        version: v0.9.1
-        source: github.com/GoCodeAlone/workflow-plugin-agent


### PR DESCRIPTION
Removes the vestigial `.wfctl-lock.yaml`.

## Why it is safe to delete
Confirmed zero consumers:
- `.github/workflows/ci.yml` runs `wfctl validate -plugin-dir data/plugins ratchet.yaml` + `wfctl contract test ratchet.yaml` — neither command reads the lockfile.
- No `Makefile` / script / `.go` file references `wfctl-lock` anywhere in the tree.

## Why it is stale
The lockfile pins `name: ratchet` → `workflow-plugin-agent@v0.9.1` — wrong name, wrong version, and the wrong source shape now that the agent plugin ships real cross-compiled gRPC binary assets (v0.10.0, cataloged in the registry via workflow-registry#484). Keeping it would only cause confusion.

This is the conditional 3rd-repo change in the Phase 1 Task 3 scope manifest.

Lead to merge. Do not merge/tag here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)