### PR TITLE
chore: bump workflow agent dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/GoCodeAlone/ratchet
 go 1.26.4
 
 require (
-	github.com/GoCodeAlone/workflow v0.84.0
-	github.com/GoCodeAlone/workflow-plugin-agent v0.12.0
+	github.com/GoCodeAlone/workflow v0.85.2
+	github.com/GoCodeAlone/workflow-plugin-agent v0.12.2
 	github.com/GoCodeAlone/workflow-plugin-auth v0.4.0
 	github.com/GoCodeAlone/workflow-plugin-infra v1.7.0
 	modernc.org/sqlite v1.53.0
@@ -20,7 +20,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/DataDog/datadog-go/v5 v5.8.3 // indirect
 	github.com/GoCodeAlone/go-plugin v1.7.0 // indirect
-	github.com/GoCodeAlone/modular v1.13.4 // indirect
+	github.com/GoCodeAlone/modular v1.13.5 // indirect
 	github.com/GoCodeAlone/modular/modules/auth v1.17.0 // indirect
 	github.com/GoCodeAlone/modular/modules/cache v1.17.0 // indirect
 	github.com/GoCodeAlone/modular/modules/eventbus/v2 v2.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/DataDog/datadog-go/v5 v5.8.3 h1:s58CUJ9s8lezjhTNJO/SxkPBv2qZjS3ktpRSq
 github.com/DataDog/datadog-go/v5 v5.8.3/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/GoCodeAlone/go-plugin v1.7.0 h1:EwnhqPlXiNmp85S+MXnKKvm3YlfA6O4NzBb4+GSlEVY=
 github.com/GoCodeAlone/go-plugin v1.7.0/go.mod h1:HbGQRZUIa+jbDfjsaZIMJYvrz+LnxL0mJpggfynSTMk=
-github.com/GoCodeAlone/modular v1.13.4 h1:De4p2qyJSVmstRGno/PM+fPdUCMu/7a9WgU5FUVGDa8=
-github.com/GoCodeAlone/modular v1.13.4/go.mod h1:+JEPUYOxGaD332EMZ5PbJCz5rxwvFu4Tm6MrnZT0vxM=
+github.com/GoCodeAlone/modular v1.13.5 h1:Q+AR3MMAQJctvPJzlRSmTywArbrsXiMM3gzyJN8reBs=
+github.com/GoCodeAlone/modular v1.13.5/go.mod h1:+JEPUYOxGaD332EMZ5PbJCz5rxwvFu4Tm6MrnZT0vxM=
 github.com/GoCodeAlone/modular/modules/auth v1.17.0 h1:GbKG6s/2qe6N9YZ8vtvYsNon56MLWECncPxWvAsazSc=
 github.com/GoCodeAlone/modular/modules/auth v1.17.0/go.mod h1:E9dDIxiAxIrXK8gn/rEhaqI5OYe6Aw/uGpRyI7iyxj8=
 github.com/GoCodeAlone/modular/modules/cache v1.17.0 h1:1cColHYfF7aFZhxBjS4RuZ2wBOYWAIVr5GkJ3nk5VIA=
@@ -33,10 +33,10 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.17.0 h1:zoWioqUvuNNDfnjHA1s
 github.com/GoCodeAlone/modular/modules/jsonschema v1.17.0/go.mod h1:GDU/jsD6AddmXKedj0wZwieUIaQsTBSGMzuj+XHXMrw=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.10.0 h1:+2M/ecyCxDiXfJM4ibcERuu/BBeIbLTQNcVgRsllR64=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.10.0/go.mod h1:tlVH1mA5yuU8CB7R7+HXIRaBixZoNid6h+5tew5u3FU=
-github.com/GoCodeAlone/workflow v0.84.0 h1:JJX91+h7QaZ9xUJEBcTrlhvebCVI+/9/2kLn1emckzs=
-github.com/GoCodeAlone/workflow v0.84.0/go.mod h1:vBi/HkWBt8LrZ/J3E61bx/Q4MSh15ieXy8sIEqK5lNU=
-github.com/GoCodeAlone/workflow-plugin-agent v0.12.0 h1:hYvsALgYxDt1Ti/hZa9rmy3s42ZU4lt3K0Y9YUT+ejk=
-github.com/GoCodeAlone/workflow-plugin-agent v0.12.0/go.mod h1:E3ciphc2GFgtxFugQO7S35mlnFVOWEF3+s+Qi6vzO5M=
+github.com/GoCodeAlone/workflow v0.85.2 h1:u65GfzC0c1bkicOOvyPbgcB1rhodexWd7f+wR6V6o1E=
+github.com/GoCodeAlone/workflow v0.85.2/go.mod h1:tqWHdWHCn2ESB4Rj6FiRjKchof9zjcs11o8AtfOiZaU=
+github.com/GoCodeAlone/workflow-plugin-agent v0.12.2 h1:zmrwdRlb37hr9aZs+oNW9Oub369B/coeG+eXuec+ABg=
+github.com/GoCodeAlone/workflow-plugin-agent v0.12.2/go.mod h1:YKSaEo28dYbP2UkrRVjEcrIToMAXfLkTrtlz6Sbv4m8=
 github.com/GoCodeAlone/workflow-plugin-auth v0.4.0 h1:LpiN8BNBUc0auDBJy5GegYMfGeBL/qngLdaTzwE/uFU=
 github.com/GoCodeAlone/workflow-plugin-auth v0.4.0/go.mod h1:0mn9cyxNBvwoIxa1TmNqqgIHD4HYiZoDL5UWoKWNuTg=
 github.com/GoCodeAlone/workflow-plugin-authz v0.5.4 h1:z33pySf4R5VT6pZSXrNqzJLKJ93srmoJ6UnIV7cPG5I=


### PR DESCRIPTION
## Summary
- bump workflow to v0.85.2
- bump workflow-plugin-agent to v0.12.2
- bump modular to v1.13.5 transitively

## Verification
- GOWORK=off go test ./...