### PR TITLE
ci: publish ratchet release after uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Upload Release Assets
         uses: softprops/action-gh-release@v2
         with:
+          draft: true
           files: dist/*.tar.gz
 
   ui-release:
@@ -119,14 +120,27 @@ jobs:
       - name: Upload UI dist
         uses: softprops/action-gh-release@v2
         with:
+          draft: true
           files: ui/dist/**
+
+  publish-release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs: [release, ui-release]
+    steps:
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"
 
   notify-workflow-registry:
     name: Notify workflow-registry
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: release
+    needs: publish-release
     if: >-
       !github.event.deleted
       && !contains(github.ref_name, '-')


### PR DESCRIPTION
## Summary
- upload ratchet release assets to a draft release first
- publish the GitHub release only after matrix and UI assets finish uploading
- make workflow-registry notification depend on the publish step

## Root cause
The v0.1.18 release published as soon as the UI asset job completed, then binary matrix uploads failed against GitHub's immutable release rule.

## Verification
- actionlint .github/workflows/release.yml .github/workflows/ci.yml
- fresh workflow-ui v0.2.0 checkout: npm ci && npm run build
- ratchet ui with pinned workflow-ui symlink: npm ci && npm run build